### PR TITLE
now resolving targets only once, with MastClass.resolve_object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,9 @@ Please include a self-contained example that fully demonstrates your problem or 
 
 Changelog:
 ==========
-
+v1.0.1
+  - Now resolving target search strings with MastClass [#27]
+v1.0
   - The class structure has been modified. The base class is MASTSearch. Users are intended to use mission-specific classes (KeplerSearch/K2Search/TESSSearch) to obtain mission-specific results.
   - Result tables are saved as pandas dataframs
   - The TESScut search functionality now uses tesswcs to identify observed sectors

--- a/docs/tutorials/Example_searches.ipynb
+++ b/docs/tutorials/Example_searches.ipynb
@@ -320,7 +320,7 @@
    ],
    "source": [
     "# Let's use this to check what mission(s) have observed this target\n",
-    "print(search_result.mission)\n"
+    "print(search_result.mission)"
    ]
   },
   {
@@ -338,7 +338,9 @@
     }
    ],
    "source": [
-    "print(f\"There are {sum(search_result.mission == 'TESS')} observations by TESS and {sum(search_result.mission == 'Kepler')} by Kepler\")\n"
+    "print(\n",
+    "    f\"There are {sum(search_result.mission == 'TESS')} observations by TESS and {sum(search_result.mission == 'Kepler')} by Kepler\"\n",
+    ")"
    ]
   },
   {
@@ -974,8 +976,8 @@
     }
    ],
    "source": [
-    "# Search for TESS data only. This by default includes both HLSPs and FFI cutouts. \n",
-    "toi = TESSSearch('TOI 1161')\n",
+    "# Search for TESS data only. This by default includes both HLSPs and FFI cutouts.\n",
+    "toi = TESSSearch(\"TOI 1161\")\n",
     "toi"
    ]
   },
@@ -1593,7 +1595,7 @@
     }
    ],
    "source": [
-    "# Only return data validation products. These are PDFs generated automatically during transit searches. \n",
+    "# Only return data validation products. These are PDFs generated automatically during transit searches.\n",
     "toi_dv = toi.dvreports\n",
     "toi_dv"
    ]
@@ -2187,7 +2189,7 @@
    "source": [
     "# Keep any data type, but only the shortest cadence available, which in this case is 2-minute data\n",
     "\n",
-    "toi_shortest = toi.filter_table(exptime='shortest')\n",
+    "toi_shortest = toi.filter_table(exptime=\"shortest\")\n",
     "toi_shortest"
    ]
   },
@@ -2394,7 +2396,7 @@
    ],
    "source": [
     "# You could also specify an exact exposure time or range in the form of a tuple (eg, (100,500))\n",
-    "toi_trange = toi.filter_table(exptime=(100,500))\n",
+    "toi_trange = toi.filter_table(exptime=(100, 500))\n",
     "toi_trange"
    ]
   },
@@ -2742,7 +2744,7 @@
     }
    ],
    "source": [
-    "toi_short_lcs = toi.timeseries.query_table('sector == 14 & exptime == 120')\n",
+    "toi_short_lcs = toi.timeseries.query_table(\"sector == 14 & exptime == 120\")\n",
     "toi_short_lcs"
    ]
   },
@@ -2903,7 +2905,7 @@
     "search_result = TESSSearch(\"TOI 270\", hlsp=False)\n",
     "\n",
     "# You can filter two different ways to get the same result.\n",
-    "#search_result.filter_table(pipeline='TESScut')\n",
+    "# search_result.filter_table(pipeline='TESScut')\n",
     "search_result.tesscut"
    ]
   },
@@ -3695,7 +3697,7 @@
    ],
    "source": [
     "# What timeseries data is available?\n",
-    "kep = KeplerSearch('Kepler 137')\n",
+    "kep = KeplerSearch(\"Kepler 137\")\n",
     "kep"
    ]
   },
@@ -4020,7 +4022,7 @@
    "source": [
     "# You can download a subsection of results directly\n",
     "manifest = kep[:2].download()\n",
-    "print(manifest['Local Path'].values)"
+    "print(manifest[\"Local Path\"].values)"
    ]
   },
   {
@@ -4210,7 +4212,7 @@
    ],
    "source": [
     "# we can also filter the results by observing quarter\n",
-    "kep_quarters = kep.filter_table(quarter=[7,17])\n",
+    "kep_quarters = kep.filter_table(quarter=[7, 17])\n",
     "kep_quarters"
    ]
   },
@@ -4472,7 +4474,7 @@
    "source": [
     "# Download all lightcurves produced by HLSPs\n",
     "K2_HLSPs = K2.HLSPs\n",
-    "K2_HLSPs\n"
+    "K2_HLSPs"
    ]
   },
   {
@@ -4601,6 +4603,7 @@
    ],
    "source": [
     "from lksearch import config as lkconfig\n",
+    "\n",
     "lkconfig.get_cache_dir()"
    ]
   },
@@ -4621,6 +4624,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
     "# The manifest returned by download() is a pandas DataFrame\n",
     "# We will access the first local path using iloc as so\n",
     "os.remove(manifest.iloc[0][\"Local Path\"])"
@@ -4683,7 +4687,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lkconfig.create_config_file(overwrite = True)"
+    "lkconfig.create_config_file(overwrite=True)"
    ]
   },
   {
@@ -4822,14 +4826,15 @@
     }
    ],
    "source": [
-    "#First, lets update our configuration to not download a cloud-hosted file\n",
+    "# First, lets update our configuration to not download a cloud-hosted file\n",
     "from lksearch import Conf\n",
-    "Conf.DOWNLOAD_CLOUD=False\n",
     "\n",
-    "# Now, lets find some data. We use this target earlier in the tutorial.  \n",
-    "toi = TESSSearch('TOI 1161')\n",
+    "Conf.DOWNLOAD_CLOUD = False\n",
     "\n",
-    "#What happens when we try to download it in our updated configuration? \n",
+    "# Now, lets find some data. We use this target earlier in the tutorial.\n",
+    "toi = TESSSearch(\"TOI 1161\")\n",
+    "\n",
+    "# What happens when we try to download it in our updated configuration?\n",
     "cloud_result = toi.timeseries.mission_products[0].download()\n",
     "cloud_result"
    ]
@@ -4860,7 +4865,10 @@
    ],
    "source": [
     "import astropy.io.fits as fits\n",
-    "with fits.open(cloud_result[\"Local Path\"].values[0], use_fsspec=True, fsspec_kwargs={\"anon\": True}) as hdu:\n",
+    "\n",
+    "with fits.open(\n",
+    "    cloud_result[\"Local Path\"].values[0], use_fsspec=True, fsspec_kwargs={\"anon\": True}\n",
+    ") as hdu:\n",
     "    for item in hdu:\n",
     "        print(item.fileinfo())"
    ]

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -1,4 +1,5 @@
 from astroquery.mast import Observations
+from astroquery.mast import MastClass
 import pandas as pd
 from typing import Union, Optional
 import re
@@ -467,7 +468,7 @@ class MASTSearch(object):
             - If tuple, assumes RA dec - sets search string based on coordinates &
                 creates self.SkyCoord
             - if str, assumes target name - sets search string to input string &
-                creates self.SkyCoord from SkyCoord.from_name
+                creates self.SkyCoord from `MastClass().resolve_object()`
 
         Parameters
         ----------
@@ -491,8 +492,8 @@ class MASTSearch(object):
             self.SkyCoord = SkyCoord(*search_input, frame="icrs", unit="deg")
 
         elif isinstance(search_input, str):
-            self.target_search_string = search_input
-            self.SkyCoord = SkyCoord.from_name(search_input, frame="icrs")
+            self.SkyCoord = MastClass().resolve_object(search_input)
+            self.target_search_string = f"{self.SkyCoord.ra.deg}, {self.SkyCoord.dec.deg}"
 
             target_lower = str(search_input).lower()
             target_str = self._check_exact(target_lower)

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -493,7 +493,9 @@ class MASTSearch(object):
 
         elif isinstance(search_input, str):
             self.SkyCoord = MastClass().resolve_object(search_input)
-            self.target_search_string = f"{self.SkyCoord.ra.deg}, {self.SkyCoord.dec.deg}"
+            self.target_search_string = (
+                f"{self.SkyCoord.ra.deg}, {self.SkyCoord.dec.deg}"
+            )
 
             target_lower = str(search_input).lower()
             target_str = self._check_exact(target_lower)


### PR DESCRIPTION
This is a pull request to resolve Issue #26 where lksearch was returning an exception for some TOI's. To resolve this, unify behaviour, and only resolve a target once:

1. In the case of a user passing a named search string we are now resolving this with `MastClass.resolve_object` explicitly in `MASTSearch._pase_input`
2. `MastClass.resolve_object` returns a `SkyCoord` with the position of the resolved target
3. We then use the position of this resolved `SkyCoord` object to explicitly perform a cone search with `~astroquery.Observations.query_criteria`