### PR TITLE
Bulk download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,12 @@ Please include a self-contained example that fully demonstrates your problem or 
 
 Changelog:
 ==========
+v1.2.0
+  - Made the catalogsearch functions case-insensitive[#38]
+  - Added `CHECK_CACHED_FILE_SIZES` configuration parameter, which on download allows local checking of cached files without a remote file-size check[#34][#38]
+  - Refactored `~lksearch.MastSearch.download` function to only call `~astroquery.mast.Observations.download` once 
+    - This results in a modest speedup O(N), particularly for files in the local cache when `CHECK_CACHED_FILE_SIZES` is `True`.  
+  - Updated tests, documentation for the new features
 v1.1.1
   - Deprecated TESSSearch.search_sector_ffis due to changes in astroquery functionality
 v1.1.0

--- a/docs/tutorials/cloud-data-searches.ipynb
+++ b/docs/tutorials/cloud-data-searches.ipynb
@@ -62,13 +62,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Downloading products: 100%|████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  1.94it/s]\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -138,7 +131,8 @@
     "from lksearch import K2Search\n",
     "\n",
     "##First lets download a few files\n",
-    "manifest = K2Search(\"K2-18\").HLSPs.timeseries.download()\n",
+    "K218 = K2Search(\"K2-18\").HLSPs.timeseries\n",
+    "manifest = K218.download()\n",
     "manifest"
    ]
   },
@@ -197,106 +191,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5782847-4de5-40b0-aab5-78d75d0a0c8e",
+   "id": "04c761fe-a480-43aa-b4c7-e858322bec54",
    "metadata": {},
    "source": [
-    "### lksearch Configuration and Configuration File\n",
-    "lksearch has a number of configuration parameters, these are contained in the `~lksearch.Conf` [class](https://lightkurve.github.io/lksearch/apidoc.html#lksearch.Conf).  One can modify these parameters for a given python session by updating the values in the Conf class.  To modify these configuration parameters default values, lksearch also has an optional configuration file that is built on-top of `~astropy.config` using `~astropy.config.ConfigNamespace`. This file does not exist by default, but a default version can be created using the `config.create_config_file` helper function.  Modifications to the values in this file will then update the default `~lksearch.Conf` values.  "
+    "#### Caching and File Downloads\n",
+    "By default, lksearch will use the `~astroquery.mast.Observations` built in caching functionality which includes a file-size check to verify the completeness of a download and static nature of a file.  This means that if a file is truncated mid-download, or gets updated on the MAST archive (rare but not unheard of), this will detect a mismatch and re-download the file.  This does, however, add some small overhead to file downloads and can add additional remote calls.  \n",
+    "\n",
+    "If this behaviour is undesired, the CHECK_CACHED_FILE_SIZES configuration parameter can be set to `False` - this will cause the download function to check for the presence of a local file  with the appropriate name/location of the desired download, and if it exists pass the local file location with a modified `Status` tag.  \n",
+    "\n",
+    "This will be lest robust but slightly faster and with potentially fewer remote calls.\n",
+    "\n",
+    "For example, with file size checking:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "6662b57f-70d9-4a1f-82f4-79ea56c3d7c8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lkconfig.create_config_file(overwrite=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "36de9527-3ba9-492c-8687-6a48d23b9e5f",
-   "metadata": {},
-   "source": [
-    "This file can be found in the below location.  To edit this, please see the astropy.config documentation.  "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "1d114c6a-bf53-4212-94c0-8309a3a12895",
+   "id": "7941ff5f-f5c1-46e4-a0e2-1da55b540449",
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/Users/tapritc2/.lksearch/config'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lkconfig.get_config_dir()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "54d1962b-a74c-407f-9d69-3e048b239a7c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/Users/tapritc2/.lksearch/config/lksearch.cfg'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lkconfig.get_config_file()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "72533d4f-c8af-4085-9f9c-50f01955f118",
-   "metadata": {},
-   "source": [
-    "## lksearch Cloud Configuration\n",
-    "`lksearch` has three configuration parameters that are particularly relevant to cloud-based science platforms.  These are:\n",
-    "    - `CLOUD_ONLY`: Only Download cloud based data. If `False`, will download all data. If `True`, will only download data located on a cloud (Amazon S3) bucket\n",
-    "    - `PREFER_CLOUD`: Prefer Cloud-based data product retrieval where available\n",
-    "    - `DOWNLOAD_CLOUD`: Download cloud based data. If `False`, download() will return a pointer to the cloud based datainstead of downloading it - intended usage for cloud-based science platforms (e.g. TiKE)\n",
-    "\n",
-    "`CLOUD_ONLY` governs whether or not non-cloud based data will be possible to be downloaded.  Many science files have both a cloud-based location (typically on Amazon S3) and a MAST archive location. By default this is `False`, and all products will be downloaded regardless of whether the file is available via cloud-hosting or MAST archive hosting. If `CLOUD_ONLY` is `True`, only files available for download on a cloud-based platform will be retrieved.  This configuration parameter is passed through to the `~astroquery.mast` parameter of the same name.  \n",
-    "\n",
-    "`PREFER_CLOUD` governs the default download behaviour in the event that a data product is available from both a cloud-based location and a MAST-hosted archive location.  If `True` (default), then `lksearch` will preferentially download files from the cloud-host rather than the MAST-hosted Archive. This configuration parameter is passed through to the `~astroquery.mast` parameter of the same name.  \n",
-    "\n",
-    "`DOWNLOAD_CLOUD` governs whether files that are hosted on the cloud are downloaded locally. If this value is `True` (default), cloud-hosted files are downloaded normally.  If `False`, then files hosted on a cloud based platform are not downloaded, and a URI containing the path to the desired file on the cloud-host is returned instead of the local path to the file.  This path can then be used to read the file remotely (see `~astropy.io.fits` [working with remote and cloud hosted files](https://docs.astropy.org/en/stable/io/fits/#working-with-remote-and-cloud-hosted-files:~:text=with%20large%20files-,Working%20with%20remote%20and%20cloud%2Dhosted%20files,-Unsigned%20integers) for more information). This ability may be most relevant when using `lksearch` on a cloud-based science platform where the remote read is very rapid and short-term local storage comparatively expensive.  \n",
-    "\n",
-    "Using this `DOWNLOAD_CLOUD` functionality, we can find a cloud-hosted file and read it directly into memory like so:\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "ff63034a-75de-4bf4-bc74-931e472d9af3",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Downloading products: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 584.16it/s]\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -327,7 +240,237 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>s3://stpubdata/tess/public/tid/s0014/0000/0001...</td>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/H...</td>\n",
+       "      <td>COMPLETE</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                          Local Path    Status Message   URL\n",
+       "0  /Users/tapritc2/.lksearch/cache/mastDownload/H...  COMPLETE    None  None"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from lksearch import conf\n",
+    "\n",
+    "conf.reload()\n",
+    "conf.CHECK_CACHED_FILE_SIZES = True\n",
+    "K218[0].download()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "609afad8-c3a2-478a-ac92-845635762f8f",
+   "metadata": {},
+   "source": [
+    "And without file size checking:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f98f1ccf-de7b-413c-ab8b-43f70a26af46",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Local Path</th>\n",
+       "      <th>Status</th>\n",
+       "      <th>Message</th>\n",
+       "      <th>URL</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/H...</td>\n",
+       "      <td>UNKNOWN</td>\n",
+       "      <td>File exists in local cache, has not been valid...</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                          Local Path   Status  \\\n",
+       "0  /Users/tapritc2/.lksearch/cache/mastDownload/H...  UNKNOWN   \n",
+       "\n",
+       "                                             Message   URL  \n",
+       "0  File exists in local cache, has not been valid...  None  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conf.CHECK_CACHED_FILE_SIZES = False\n",
+    "K218[0].download()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5782847-4de5-40b0-aab5-78d75d0a0c8e",
+   "metadata": {},
+   "source": [
+    "### lksearch Configuration and Configuration File\n",
+    "lksearch has a number of configuration parameters, these are contained in the `~lksearch.Conf` [class](https://lightkurve.github.io/lksearch/apidoc.html#lksearch.Conf).  One can modify these parameters for a given python session by updating the values in the Conf class.  To modify these configuration parameters default values, lksearch also has an optional configuration file that is built on-top of `~astropy.config` using `~astropy.config.ConfigNamespace`. This file does not exist by default, but a default version can be created using the `config.create_config_file` helper function.  Modifications to the values in this file will then update the default `~lksearch.Conf` values.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6662b57f-70d9-4a1f-82f4-79ea56c3d7c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lkconfig.create_config_file(overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36de9527-3ba9-492c-8687-6a48d23b9e5f",
+   "metadata": {},
+   "source": [
+    "This file can be found in the below location.  To edit this, please see the astropy.config documentation.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1d114c6a-bf53-4212-94c0-8309a3a12895",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/tapritc2/.lksearch/config'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lkconfig.get_config_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "54d1962b-a74c-407f-9d69-3e048b239a7c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/tapritc2/.lksearch/config/lksearch.cfg'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lkconfig.get_config_file()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72533d4f-c8af-4085-9f9c-50f01955f118",
+   "metadata": {},
+   "source": [
+    "## lksearch Cloud Configuration\n",
+    "`lksearch` has three configuration parameters that are particularly relevant to cloud-based science platforms.  These are:\n",
+    "    - `CLOUD_ONLY`: Only Download cloud based data. If `False`, will download all data. If `True`, will only download data located on a cloud (Amazon S3) bucket\n",
+    "    - `PREFER_CLOUD`: Prefer Cloud-based data product retrieval where available\n",
+    "    - `DOWNLOAD_CLOUD`: Download cloud based data. If `False`, download() will return a pointer to the cloud based datainstead of downloading it - intended usage for cloud-based science platforms (e.g. TiKE)\n",
+    "\n",
+    "`CLOUD_ONLY` governs whether or not non-cloud based data will be possible to be downloaded.  Many science files have both a cloud-based location (typically on Amazon S3) and a MAST archive location. By default this is `False`, and all products will be downloaded regardless of whether the file is available via cloud-hosting or MAST archive hosting. If `CLOUD_ONLY` is `True`, only files available for download on a cloud-based platform will be retrieved.  This configuration parameter is passed through to the `~astroquery.mast` parameter of the same name.  \n",
+    "\n",
+    "`PREFER_CLOUD` governs the default download behaviour in the event that a data product is available from both a cloud-based location and a MAST-hosted archive location.  If `True` (default), then `lksearch` will preferentially download files from the cloud-host rather than the MAST-hosted Archive. This configuration parameter is passed through to the `~astroquery.mast` parameter of the same name.  \n",
+    "\n",
+    "`DOWNLOAD_CLOUD` governs whether files that are hosted on the cloud are downloaded locally. If this value is `True` (default), cloud-hosted files are downloaded normally.  If `False`, then files hosted on a cloud based platform are not downloaded, and a URI containing the path to the desired file on the cloud-host is returned instead of the local path to the file.  This path can then be used to read the file remotely (see `~astropy.io.fits` [working with remote and cloud hosted files](https://docs.astropy.org/en/stable/io/fits/#working-with-remote-and-cloud-hosted-files:~:text=with%20large%20files-,Working%20with%20remote%20and%20cloud%2Dhosted%20files,-Unsigned%20integers) for more information). This ability may be most relevant when using `lksearch` on a cloud-based science platform where the remote read is very rapid and short-term local storage comparatively expensive.  \n",
+    "\n",
+    "Using this `DOWNLOAD_CLOUD` functionality, we can find a cloud-hosted file and read it directly into memory like so:\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ff63034a-75de-4bf4-bc74-931e472d9af3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Local Path</th>\n",
+       "      <th>Status</th>\n",
+       "      <th>Message</th>\n",
+       "      <th>URL</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>/Users/tapritc2/.lksearch/cache/mastDownload/T...</td>\n",
+       "      <td>UNKNOWN</td>\n",
+       "      <td>File exists in local cache, has not been valid...</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0    s3://stpubdata/tess/public/tid/s0014/0000...</td>\n",
        "      <td>COMPLETE</td>\n",
        "      <td>Link to S3 bucket for remote read</td>\n",
        "      <td>None</td>\n",
@@ -338,13 +481,15 @@
       ],
       "text/plain": [
        "                                          Local Path    Status  \\\n",
-       "0  s3://stpubdata/tess/public/tid/s0014/0000/0001...  COMPLETE   \n",
+       "0  /Users/tapritc2/.lksearch/cache/mastDownload/T...   UNKNOWN   \n",
+       "0  0    s3://stpubdata/tess/public/tid/s0014/0000...  COMPLETE   \n",
        "\n",
-       "                             Message   URL  \n",
-       "0  Link to S3 bucket for remote read  None  "
+       "                                             Message   URL  \n",
+       "0  File exists in local cache, has not been valid...  None  \n",
+       "0                  Link to S3 bucket for remote read  None  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -375,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "6f4f92ad-e754-4e58-abf2-54d6fab0fd08",
    "metadata": {},
    "outputs": [
@@ -383,9 +528,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'file': <astropy.io.fits.file._File <File-like object S3FileSystem, stpubdata/tess/public/tid/s0014/0000/0001/5832/4245/tess2019198215352-s0014-0000000158324245-0150-s_lc.fits>>, 'filemode': 'readonly', 'hdrLoc': 0, 'datLoc': 5760, 'datSpan': 0}\n",
-      "{'file': <astropy.io.fits.file._File <File-like object S3FileSystem, stpubdata/tess/public/tid/s0014/0000/0001/5832/4245/tess2019198215352-s0014-0000000158324245-0150-s_lc.fits>>, 'filemode': 'readonly', 'hdrLoc': 5760, 'datLoc': 20160, 'datSpan': 1935360}\n",
-      "{'file': <astropy.io.fits.file._File <File-like object S3FileSystem, stpubdata/tess/public/tid/s0014/0000/0001/5832/4245/tess2019198215352-s0014-0000000158324245-0150-s_lc.fits>>, 'filemode': 'readonly', 'hdrLoc': 1955520, 'datLoc': 1961280, 'datSpan': 2880}\n"
+      "{'file': <astropy.io.fits.file._File <fsspec.implementations.local.LocalFileOpener object at 0x150b62740>>, 'filemode': 'readonly', 'hdrLoc': 0, 'datLoc': 5760, 'datSpan': 0}\n",
+      "{'file': <astropy.io.fits.file._File <fsspec.implementations.local.LocalFileOpener object at 0x150b62740>>, 'filemode': 'readonly', 'hdrLoc': 5760, 'datLoc': 20160, 'datSpan': 1935360}\n",
+      "{'file': <astropy.io.fits.file._File <fsspec.implementations.local.LocalFileOpener object at 0x150b62740>>, 'filemode': 'readonly', 'hdrLoc': 1955520, 'datLoc': 1961280, 'datSpan': 2880}\n"
      ]
     }
    ],
@@ -398,20 +543,6 @@
     "    for item in hdu:\n",
     "        print(item.fileinfo())"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8d43578c-b414-4ea3-aa8e-1da55e5f548f",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "726de463-2a7f-4a51-88b6-f7abe59b3082",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/data-searches.ipynb
+++ b/docs/tutorials/data-searches.ipynb
@@ -273,7 +273,7 @@
     "- obsrvation year (year)\n",
     "- reduction pipeline (pipeline)\n",
     "- data location URI (uris)\n",
-    "- data location in cloud storage (cloud_uris)\n",
+    "- data location in cloud storage (cloud_uri)\n",
     "\n"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lksearch"
-version = "1.1.0"
+version = "1.2.0"
 description = "A helpful little package to search for TESS/Kepler/K2 data"
 authors = ["TESS Science Support Center <tesshelp@bigbang.gsfc.nasa.gov>"]
 license = "MIT"

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -1131,7 +1131,7 @@ class MASTSearch(object):
         # If so - cloud_uris should have already been queried - in that case
         # check to see if a cloud_uri exists, if so we just pass that
 
-        skip_download = np.zeros_like(self.table.obs_id).astype(dtype=bool)
+        skip_download = np.zeros(len(self.table.obs_id), dtype=bool)
         cloud_manifest = None
         local_manifest = None
         download_manifest = None

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -1152,7 +1152,7 @@ class MASTSearch(object):
                     },
                     index=self.table.index[cloud_uri_exists & files_to_check],
                 )
-            files_to_check = files_to_check & ~(files_to_check & cloud_uri_exists)
+            files_to_check = ~cloud_uri_exists
 
         if not conf.CHECK_CACHED_FILE_SIZES:
             # If this configuration parameter is `False` and the file exists

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -1137,7 +1137,7 @@ class MASTSearch(object):
         download_manifest = None
 
         if not conf.CHECK_CACHED_FILE_SIZES:
-            # If this configuration parameter is set and the file exists
+            # If this configuration parameter is `False` and the file exists
             # in the cache, we do not search for it
             files_in_cache, local_paths = self._check_local_cache()
 

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -106,11 +106,7 @@ class MASTSearch(object):
 
         self.target = target
 
-        if (
-            isinstance(table, type(None))
-            and isinstance(obs_table, type(None))
-            and isinstance(prod_table, type(None))
-        ):
+        if isinstance(table, type(None)):
             self._searchtable_from_target(target)
             self.table = self._fix_table_times(self.table)
 
@@ -327,15 +323,15 @@ class MASTSearch(object):
         # see if function was passed a joint table
         if isinstance(table, pd.DataFrame):
             self.table = table
+
         # If we don't have a name or a joint table,
         # check to see if tables were passed
-
         elif isinstance(obs_table, pd.DataFrame):
             # If we have an obs table and no name, use it
             self.obs_table = obs_table
             if isinstance(prod_table, type(None)):
                 # get the prod table if we don't have it
-                prod_table = self._search_prod()
+                prod_table = self._search_products(self)
             self.prod_table = prod_table
             self.table = self._join_tables()
         else:

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -1119,7 +1119,7 @@ class MASTSearch(object):
     ) -> pd.DataFrame:
         """Helper function that downloads an entire table via astroquery.
         This will require internet access and check file sizes against MAST
-        to validate completeness if the conf.CHECK_CACHED_FILE_SIZES is not set.
+        to validate completeness, unless conf.CHECK_CACHED_FILE_SIZES is `False`
         """
 
         # Make sure astroquery uses the same level of verbosity

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -106,7 +106,11 @@ class MASTSearch(object):
 
         self.target = target
 
-        if isinstance(table, type(None)):
+        if (
+            isinstance(table, type(None))
+            and isinstance(obs_table, type(None))
+            and isinstance(prod_table, type(None))
+        ):
             self._searchtable_from_target(target)
             self.table = self._fix_table_times(self.table)
 
@@ -320,15 +324,15 @@ class MASTSearch(object):
         # see if function was passed a joint table
         if isinstance(table, pd.DataFrame):
             self.table = table
-
         # If we don't have a name or a joint table,
         # check to see if tables were passed
+
         elif isinstance(obs_table, pd.DataFrame):
             # If we have an obs table and no name, use it
             self.obs_table = obs_table
             if isinstance(prod_table, type(None)):
                 # get the prod table if we don't have it
-                prod_table = self._search_products(self)
+                prod_table = self._search_prod()
             self.prod_table = prod_table
             self.table = self._join_tables()
         else:

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -1126,17 +1126,16 @@ class MASTSearch(object):
         logging.getLogger("astropy").setLevel(log.getEffectiveLevel())
         logging.getLogger("astroquery").setLevel(log.getEffectiveLevel())
 
-        # We don't want to query cloud_uri if we don't have to
-        # First check to see if we're not downloading on a cloud platform
-        # If so - cloud_uris should have already been queried - in that case
-        # check to see if a cloud_uri exists, if so we just pass that
-
         files_to_check = np.ones(len(self.table.obs_id), dtype=bool)
         cloud_manifest = None
         local_manifest = None
         download_manifest = None
 
         if not conf.DOWNLOAD_CLOUD:
+            # If we are on a cloud platform, and do not want to download items with cloud_uris
+            # E.G. DOWNLOAD_CLOUD = FALSE
+            # Then cloud_uris should have already been queried
+            # and so our download manifest will contain a cloud-URI for the items with a not-NA value
             cloud_uri_exists = self.table["cloud_uri"].notna()
 
             if cloud_uri_exists.any():

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -88,6 +88,14 @@ class TESSSearch(MASTSearch):
             self.mission_search = ["TESS"]
         else:
             self.mission_search = ["TESS", "HLSP"]
+        pipeline = np.atleast_1d(pipeline)
+
+        # Sending 'pipeline' to MASTSearch init causes a SearchError, so handle that separately
+        if "tesscut" in [p.lower() for p in pipeline] or (type(pipeline) is type(None)):
+            add_tesscut = True
+            pipeline = np.delete(
+                pipeline, [p.lower() for p in pipeline].index("tesscut")
+            )
 
         super().__init__(
             target=target,
@@ -102,7 +110,7 @@ class TESSSearch(MASTSearch):
         )
 
         if table is None:
-            if ("TESScut" in np.atleast_1d(pipeline)) or (type(pipeline) is type(None)):
+            if add_tesscut:
                 self._add_tesscut_products(sector)
             self._add_TESS_mission_product()
             self._sort_TESS()
@@ -144,7 +152,7 @@ class TESSSearch(MASTSearch):
         return f"{target.group(2)}"
 
     def _add_TESS_mission_product(self):
-        """Determine whick products are HLSPs and which are mission products"""
+        """Determine which products are HLSPs and which are mission products"""
         mission_product = np.zeros(len(self.table), dtype=bool)
         mission_product[self.table["pipeline"] == "SPOC"] = True
         self.table["mission_product"] = mission_product

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -94,9 +94,7 @@ class TESSSearch(MASTSearch):
 
 
         # Sending 'pipeline' to MASTSearch init causes a SearchError, so handle that separately
-        if (type(pipeline) is type(None)) or (
-            "tesscut" in [p.lower() for p in pipeline]
-        ):
+        if (type(pipeline) is type(None)) or ("tesscut" in [p.lower() for p in pipeline]) :
             add_tesscut = True
             pipeline = np.delete(
                 pipeline, [p.lower() for p in pipeline].index("tesscut")

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -91,7 +91,9 @@ class TESSSearch(MASTSearch):
         pipeline = np.atleast_1d(pipeline)
 
         # Sending 'pipeline' to MASTSearch init causes a SearchError, so handle that separately
-        if (type(pipeline) is type(None)) or ("tesscut" in [p.lower() for p in pipeline]) :
+        if (type(pipeline) is type(None)) or (
+            "tesscut" in [p.lower() for p in pipeline]
+        ):
             add_tesscut = True
             pipeline = np.delete(
                 pipeline, [p.lower() for p in pipeline].index("tesscut")

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -92,26 +92,15 @@ class TESSSearch(MASTSearch):
         if pipeline != None:
             pipeline = np.atleast_1d(pipeline).tolist()
 
-        # Sending 'tesscut' as a pipeline options returns a SearchError to the mast search
-        # If only tesscut is desired, we can just do the search on its own.
-        if isinstance(pipeline, list):
-            if [p.lower() for p in pipeline] == ["tesscut"]:
-                if isinstance(target, SkyCoord):
-                    self.target_search_string = f"{target.ra.deg}, {target.dec.deg}"
-                    self.SkyCoord = target
-                elif isinstance(target, tuple):
-                    self.target_search_string = f"{target[0]}, {target[1]}"
-                    self.SkyCoord = SkyCoord(*target, frame="icrs", unit="deg")
-                elif isinstance(target, str):
-                    self.SkyCoord = MastClass().resolve_object(target)
-                    self.target_search_string = (
-                        f"{self.SkyCoord.ra.deg}, {self.SkyCoord.dec.deg}"
-                    )
-                obs_table = self._get_tesscut_info(sector_list=sector)
-            if "tesscut" in [p.lower() for p in pipeline]:
-                pipeline = np.delete(
-                    pipeline, [p.lower() for p in pipeline].index("tesscut")
-                )
+
+        # Sending 'pipeline' to MASTSearch init causes a SearchError, so handle that separately
+        if (type(pipeline) is type(None)) or (
+            "tesscut" in [p.lower() for p in pipeline]
+        ):
+            add_tesscut = True
+            pipeline = np.delete(
+                pipeline, [p.lower() for p in pipeline].index("tesscut")
+            )
 
         super().__init__(
             target=target,

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -91,7 +91,7 @@ class TESSSearch(MASTSearch):
         pipeline = np.atleast_1d(pipeline)
 
         # Sending 'pipeline' to MASTSearch init causes a SearchError, so handle that separately
-        if "tesscut" in [p.lower() for p in pipeline] or (type(pipeline) is type(None)):
+        if (type(pipeline) is type(None)) or ("tesscut" in [p.lower() for p in pipeline]) :
             add_tesscut = True
             pipeline = np.delete(
                 pipeline, [p.lower() for p in pipeline].index("tesscut")

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -94,10 +94,9 @@ class TESSSearch(MASTSearch):
 
         # Sending 'tesscut' as a pipeline options returns a SearchError to the mast search
         # If only tesscut is desired, we can just do the search on its own.
-        add_tesscut = False
+        add_tesscut = True
         if isinstance(pipeline, list):
             if "tesscut" in [p.lower() for p in pipeline]:
-                add_tesscut = True
                 # If only tesscut is requested, we can skip the regular MAST search
                 if [p.lower() for p in pipeline] == ["tesscut"]:
                     log.debug(f"Only performing TESScut search")
@@ -121,6 +120,9 @@ class TESSSearch(MASTSearch):
                 pipeline = np.delete(
                     pipeline, [p.lower() for p in pipeline].index("tesscut")
                 )
+            else:
+                # If pipeline is a list without 'tesscut', don't add it.
+                add_tesscut = False
 
         super().__init__(
             target=target,

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -94,9 +94,10 @@ class TESSSearch(MASTSearch):
 
         # Sending 'tesscut' as a pipeline options returns a SearchError to the mast search
         # If only tesscut is desired, we can just do the search on its own.
-        add_tesscut = True
+        add_tesscut = False
         if isinstance(pipeline, list):
             if "tesscut" in [p.lower() for p in pipeline]:
+                add_tesscut = True
                 # If only tesscut is requested, we can skip the regular MAST search
                 if [p.lower() for p in pipeline] == ["tesscut"]:
                     log.debug(f"Only performing TESScut search")
@@ -120,9 +121,6 @@ class TESSSearch(MASTSearch):
                 pipeline = np.delete(
                     pipeline, [p.lower() for p in pipeline].index("tesscut")
                 )
-            else:
-                # If pipeline is a list without 'tesscut', don't add it.
-                add_tesscut = False
 
         super().__init__(
             target=target,

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -89,16 +89,7 @@ class TESSSearch(MASTSearch):
             self.mission_search = ["TESS"]
         else:
             self.mission_search = ["TESS", "HLSP"]
-        if pipeline != None:
-            pipeline = np.atleast_1d(pipeline).tolist()
 
-
-        # Sending 'pipeline' to MASTSearch init causes a SearchError, so handle that separately
-        if "tesscut" in [p.lower() for p in pipeline] or (type(pipeline) is type(None)):
-            add_tesscut = True
-            pipeline = np.delete(
-                pipeline, [p.lower() for p in pipeline].index("tesscut")
-            )
 
         super().__init__(
             target=target,
@@ -113,8 +104,7 @@ class TESSSearch(MASTSearch):
         )
 
         if table is None:
-            # Do not append tesscut products if pipeline = 'TESScut' (it's already been done!)
-            if not obs_table:
+            if ("TESScut" in np.atleast_1d(pipeline)) or (type(pipeline) is type(None)):
                 self._add_tesscut_products(sector)
             self._add_TESS_mission_product()
             self._sort_TESS()
@@ -156,7 +146,7 @@ class TESSSearch(MASTSearch):
         return f"{target.group(2)}"
 
     def _add_TESS_mission_product(self):
-        """Determine which products are HLSPs and which are mission products"""
+        """Determine whick products are HLSPs and which are mission products"""
         mission_product = np.zeros(len(self.table), dtype=bool)
         mission_product[self.table["pipeline"] == "SPOC"] = True
         self.table["mission_product"] = mission_product

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -95,9 +95,10 @@ class TESSSearch(MASTSearch):
             "tesscut" in [p.lower() for p in pipeline]
         ):
             add_tesscut = True
-            pipeline = np.delete(
-                pipeline, [p.lower() for p in pipeline].index("tesscut")
-            )
+            if pipeline:
+                pipeline = np.delete(
+                    pipeline, [p.lower() for p in pipeline].index("tesscut")
+                )
 
         super().__init__(
             target=target,

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -94,7 +94,7 @@ class TESSSearch(MASTSearch):
 
 
         # Sending 'pipeline' to MASTSearch init causes a SearchError, so handle that separately
-        if (type(pipeline) is type(None)) or ("tesscut" in [p.lower() for p in pipeline]) :
+        if "tesscut" in [p.lower() for p in pipeline] or (type(pipeline) is type(None)):
             add_tesscut = True
             pipeline = np.delete(
                 pipeline, [p.lower() for p in pipeline].index("tesscut")

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 
 from .MASTSearch import MASTSearch
 from . import conf, config, log
-from .utils import SearchDeprecationError, table_keys
+from .utils import SearchDeprecationError
 
 PREFER_CLOUD = conf.PREFER_CLOUD
 DOWNLOAD_CLOUD = conf.DOWNLOAD_CLOUD
@@ -94,30 +94,21 @@ class TESSSearch(MASTSearch):
 
         # Sending 'tesscut' as a pipeline options returns a SearchError to the mast search
         # If only tesscut is desired, we can just do the search on its own.
-        add_tesscut = False
         if isinstance(pipeline, list):
+            if [p.lower() for p in pipeline] == ["tesscut"]:
+                if isinstance(target, SkyCoord):
+                    self.target_search_string = f"{target.ra.deg}, {target.dec.deg}"
+                    self.SkyCoord = target
+                elif isinstance(target, tuple):
+                    self.target_search_string = f"{target[0]}, {target[1]}"
+                    self.SkyCoord = SkyCoord(*target, frame="icrs", unit="deg")
+                elif isinstance(target, str):
+                    self.SkyCoord = MastClass().resolve_object(target)
+                    self.target_search_string = (
+                        f"{self.SkyCoord.ra.deg}, {self.SkyCoord.dec.deg}"
+                    )
+                obs_table = self._get_tesscut_info(sector_list=sector)
             if "tesscut" in [p.lower() for p in pipeline]:
-                add_tesscut = True
-                # If only tesscut is requested, we can skip the regular MAST search
-                if [p.lower() for p in pipeline] == ["tesscut"]:
-                    log.debug(f"Only performing TESScut search")
-                    if isinstance(target, SkyCoord):
-                        self.target_search_string = f"{target.ra.deg}, {target.dec.deg}"
-                        self.SkyCoord = target
-                    elif isinstance(target, tuple):
-                        self.target_search_string = f"{target[0]}, {target[1]}"
-                        self.SkyCoord = SkyCoord(*target, frame="icrs", unit="deg")
-                    elif isinstance(target, str):
-                        self.SkyCoord = MastClass().resolve_object(target)
-                        self.target_search_string = (
-                            f"{self.SkyCoord.ra.deg}, {self.SkyCoord.dec.deg}"
-                        )
-                    tcut = self._get_tesscut_info(sector_list=sector)
-                    # Make a df with the same keys as would be returned by the MAST search
-                    mask = [i not in tcut.keys() for i in table_keys]
-                    empty_df = pd.DataFrame(columns=table_keys[mask])
-                    table = pd.concat([empty_df, tcut], axis=1)
-                    add_tesscut = False
                 pipeline = np.delete(
                     pipeline, [p.lower() for p in pipeline].index("tesscut")
                 )
@@ -134,11 +125,12 @@ class TESSSearch(MASTSearch):
             sequence=sector,
         )
 
-        if add_tesscut:
+        if table is None:
             # Do not append tesscut products if pipeline = 'TESScut' (it's already been done!)
-            self._add_tesscut_products(sector)
-        self._add_TESS_mission_product()
-        self._sort_TESS()
+            if not obs_table:
+                self._add_tesscut_products(sector)
+            self._add_TESS_mission_product()
+            self._sort_TESS()
 
     @property
     def HLSPs(self):

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -126,8 +126,9 @@ class TESSSearch(MASTSearch):
         )
 
         if table is None:
-            # if table == None or [pself.search_pipelineadd_tesscut:
-            self._add_tesscut_products(sector)
+            # Do not append tesscut products if pipeline = 'TESScut' (it's already been done!)
+            if not obs_table:
+                self._add_tesscut_products(sector)
             self._add_TESS_mission_product()
             self._sort_TESS()
 

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -90,7 +90,6 @@ class TESSSearch(MASTSearch):
         else:
             self.mission_search = ["TESS", "HLSP"]
 
-
         super().__init__(
             target=target,
             mission=self.mission_search,

--- a/src/lksearch/__init__.py
+++ b/src/lksearch/__init__.py
@@ -4,7 +4,17 @@ from . import config as _config
 import logging
 import os
 
-__version__ = "1.1.1"
+from importlib.metadata import version, PackageNotFoundError  # noqa
+
+
+def get_version():
+    try:
+        return version("lksearch")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = get_version()
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 

--- a/src/lksearch/__init__.py
+++ b/src/lksearch/__init__.py
@@ -27,12 +27,20 @@ class Conf(_config.ConfigNamespace):
     cache_dir
         Default cache directory for data files downloaded, etc. Defaults to ``~/.lksearch/cache`` if not specified.
 
+    CLOUD_ONLY
+        If False (default), will download a file whether the source is the cloud or MAST archives.
+        If True, will only download/return uris for data located in the cloud (Amazon S3).
+
     PREFER_CLOUD
         Use Cloud-based data product retrieval where available (primarily Amazon S3 buckets for MAST holdings)
 
     DOWNLOAD_CLOUD
        Download cloud based data. If False, download() will return a pointer to the cloud based data instead of
        downloading it - intended usage for cloud-based science platforms (e.g. TIKE)
+
+    CHECK_CACHED_FILE_SIZES
+        Toggles whether to send requests to check whether the size of files in the local cache match the expected online file.
+
     """
 
     # Note: when using list or string_list datatype,
@@ -81,7 +89,7 @@ class Conf(_config.ConfigNamespace):
         True,
         "Whether to send requests to check the size of files in the cache match the expected online file."
         "If False, lksearch will assume files within the cache are complete and will not check their file size."
-        "Setting to True will create a modest speed up to retrieving paths for cached files, but will be lest robust.",
+        "Setting to True will create a modest speed up to retrieving paths for cached files, but will be lest robust, and return an 'UNKNOWN' status message",
         cfgtype="boolean",
     )
 

--- a/src/lksearch/utils.py
+++ b/src/lksearch/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import numpy as np
 from functools import wraps
 
 from . import config
@@ -37,3 +38,70 @@ def suppress_stdout(f, *args, **kwargs):
                 sys.stdout = old_out
 
     return wrapper
+
+
+# List of keys in a search result table
+table_keys = np.array(
+    [
+        "intentType",
+        "obs_collection_obs",
+        "provenance_name",
+        "instrument_name",
+        "project_obs",
+        "filters_obs",
+        "wavelength_region",
+        "target_name",
+        "target_classification",
+        "obs_id",
+        "s_ra",
+        "s_dec",
+        "dataproduct_type_obs",
+        "proposal_pi",
+        "calib_level_obs",
+        "t_min",
+        "t_max",
+        "exptime",
+        "em_min",
+        "em_max",
+        "obs_title",
+        "t_obs_release",
+        "proposal_id_obs",
+        "proposal_type",
+        "sequence_number",
+        "s_region",
+        "jpegURL",
+        "dataURL",
+        "dataRights_obs",
+        "mtFlag",
+        "srcDen",
+        "obsid",
+        "objID",
+        "objID1",
+        "distance",
+        "obsID",
+        "obs_collection",
+        "dataproduct_type",
+        "description",
+        "type",
+        "dataURI",
+        "productType",
+        "productGroupDescription",
+        "productSubGroupDescription",
+        "productDocumentationURL",
+        "project",
+        "prvversion",
+        "proposal_id",
+        "productFilename",
+        "size",
+        "parent_obsid",
+        "dataRights",
+        "calib_level_prod",
+        "filters_prod",
+        "pipeline",
+        "mission",
+        "year",
+        "start_time",
+        "end_time",
+        "targetid",
+    ]
+)

--- a/src/lksearch/utils.py
+++ b/src/lksearch/utils.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import numpy as np
 from functools import wraps
 
 from . import config
@@ -38,70 +37,3 @@ def suppress_stdout(f, *args, **kwargs):
                 sys.stdout = old_out
 
     return wrapper
-
-
-# List of keys in a search result table
-table_keys = np.array(
-    [
-        "intentType",
-        "obs_collection_obs",
-        "provenance_name",
-        "instrument_name",
-        "project_obs",
-        "filters_obs",
-        "wavelength_region",
-        "target_name",
-        "target_classification",
-        "obs_id",
-        "s_ra",
-        "s_dec",
-        "dataproduct_type_obs",
-        "proposal_pi",
-        "calib_level_obs",
-        "t_min",
-        "t_max",
-        "exptime",
-        "em_min",
-        "em_max",
-        "obs_title",
-        "t_obs_release",
-        "proposal_id_obs",
-        "proposal_type",
-        "sequence_number",
-        "s_region",
-        "jpegURL",
-        "dataURL",
-        "dataRights_obs",
-        "mtFlag",
-        "srcDen",
-        "obsid",
-        "objID",
-        "objID1",
-        "distance",
-        "obsID",
-        "obs_collection",
-        "dataproduct_type",
-        "description",
-        "type",
-        "dataURI",
-        "productType",
-        "productGroupDescription",
-        "productSubGroupDescription",
-        "productDocumentationURL",
-        "project",
-        "prvversion",
-        "proposal_id",
-        "productFilename",
-        "size",
-        "parent_obsid",
-        "dataRights",
-        "calib_level_prod",
-        "filters_prod",
-        "pipeline",
-        "mission",
-        "year",
-        "start_time",
-        "end_time",
-        "targetid",
-    ]
-)

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -443,12 +443,9 @@ def test_FFI_retrieval():
 def test_tesscut():
     """Can we find and download TESS tesscut tpfs"""
     results = TESSSearch("Kepler 16b", hlsp=False, sector=14)
-    results2 = TESSSearch("Kepler 16b", pipeline='TESScut', sector=14)
     assert len(results) == 12
     assert len(results.cubedata) == 2
-    assert len(results.tesscut) == 1
-    assert len(results.tesscut) == len(results2)
-    manifest = results.tesscut.download()
+    manifest = results.cubedata[1].download()
     assert len(manifest) == 1
 
 

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -580,7 +580,7 @@ def test_tess_return_clouduri_not_download():
 
 
 def test_cached_files_no_filesize_check():
-    """Test if turning off the file size check return the expected manigest"""
+    """Test if turning off the file size check return the expected manifest"""
 
     # reload the config, set download_cloud = False
     toi = TESSSearch("TOI 1161", sector=14).timeseries

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -551,9 +551,9 @@ def test_filter():
 def test_tess_clouduris():
     """regression test - do tesscut/nan's in dataURI column break cloud uri fetching"""
     toi = TESSSearch("TOI 1161", sector=14)
-    # 17 products should be returned
+    # 20 products should be returned
     assert len(toi.cloud_uris) == 20
-    # 5 of them should have cloud uris
+    # 6 of them should have cloud uris
     assert np.sum((toi.cloud_uris.values != None).astype(int)) == 6
 
 

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -640,6 +640,19 @@ def test_cached_files_no_filesize_check():
     assert files_man2["Status"][0] == "COMPLETE"
     assert files_man2["Status"][1] == "UNKNOWN"
 
+    files.download()
+    conf.reload()
+    conf.CHECK_CACHED_FILE_SIZES = False
+    conf.DOWNLOAD_CLOUD = False
+    manifest = files.download()
+    # This should return a minefest with 1 TESS-SPOC HLSP that is not on the cloud
+    # and one item from SPOC that is on the cloud
+    assert manifest["Local Path"][0].startswith("s3://")
+    assert manifest["Local Path"][1].startswith("/")
+
+    assert manifest["STATUS"][0] == "COMPLETE"
+    assert manifest["STATUS"][1] == "UNKNOWN"
+
 
 """The below was working for Christina but not for Tyler or Github Actions.  
 I've commented this out so we can get this merged with passing tests as I 

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -550,9 +550,9 @@ def test_filter():
 
 def test_tess_clouduris():
     """regression test - do tesscut/nan's in dataURI column break cloud uri fetching"""
-    toi = TESSSearch("TOI 1161", sector=14)
-    # 20 products should be returned
-    assert len(toi.cloud_uri) == 20
+    toi = TESSSearch("TOI 1161", hlsp=False, sector=14)
+    # 12 products should be returned
+    assert len(toi.cloud_uri) == 12
     # 6 of them should have cloud uris
     assert np.sum((toi.cloud_uri.values != None).astype(int)) == 6
 
@@ -576,25 +576,69 @@ def test_tess_return_clouduri_not_download():
     # A SPOC TPF is on the cloud, this should return a S3 bucket
     mask = toi.timeseries.pipeline == "SPOC"
     lc_man = toi.timeseries[mask][0].download()
-    assert lc_man["Local Path"][0].str.startswith("s3://").values
+    assert lc_man["Local Path"][0].startswith("s3://")
 
 
 def test_cached_files_no_filesize_check():
     """Test if turning off the file size check return the expected manifest"""
 
     # reload the config, set download_cloud = False
-    toi = TESSSearch("TOI 1161", sector=14).timeseries
+    toi = TESSSearch("TOI 1161", pipeline=["SPOC", "TESS-SPOC"], sector=14).timeseries
     file = toi.timeseries[toi.timeseries.pipeline == "SPOC"][0]
+    files = toi.timeseries[0:2]
 
+    # test if we can download a file
     conf.reload()
     conf.CHECK_CACHED_FILE_SIZES = True
     manifest = file.download()
     assert manifest["Status"].str.contains("COMPLETE").values
 
+    # Test if we can download multiple files
+    files_man = files.download()
+    assert False not in files_man["Status"].str.contains("COMPLETE")
+
+    # Test if we can check a downloaded local file in our cache without a astroquery Call
     conf.reload()
     conf.CHECK_CACHED_FILE_SIZES = False
     manifest = file.download()
     assert manifest["Status"].str.contains("UNKNOWN").values
+
+    # Test if we can do the above for multiple files
+    files_man = files.download()
+    assert False not in files_man["Status"].str.contains("UNKNOWN")
+
+    # Test if we can mix cloud S3 file links and downloaded files
+    conf.reload()
+    conf.DOWNLOAD_CLOUD = False
+    mixed_man = toi[0:2].download()
+    # Astroquery download manifest can return in a different order than the requested items
+    # check to make sure index is preserved
+    assert toi.table["productFilename"][0] == mixed_man["Local Path"][0].split("/")[-1]
+    assert toi.table["productFilename"][1] == mixed_man["Local Path"][1].split("/")[-1]
+
+    assert mixed_man["Status"][0] == "COMPLETE"
+    assert mixed_man["Status"][1] == "COMPLETE"
+    assert mixed_man["Local Path"][0].startswith("s3://")
+    assert os.path.isfile(mixed_man["Local Path"][1])
+
+    # Test if we can check a downloaded local file that exists and download a new file
+    conf.reload()
+    files_man = files.download()
+    conf.CHECK_CACHED_FILE_SIZES = False
+    os.remove(files_man["Local Path"][0])
+
+    files_man2 = files.download()
+    # Astroquery download manifest can return in a different order than the requested items
+    # check to make sure index is preserved
+    assert (
+        files.table["productFilename"][0] == files_man2["Local Path"][0].split("/")[-1]
+    )
+    assert (
+        files.table["productFilename"][1] == files_man2["Local Path"][1].split("/")[-1]
+    )
+
+    assert files_man2["Status"][0] == "COMPLETE"
+    assert files_man2["Status"][1] == "UNKNOWN"
 
 
 """The below was working for Christina but not for Tyler or Github Actions.  

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -440,9 +440,12 @@ def test_FFI_retrieval():
 def test_tesscut():
     """Can we find and download TESS tesscut tpfs"""
     results = TESSSearch("Kepler 16b", hlsp=False, sector=14)
+    results2 = TESSSearch("Kepler 16b", pipeline='TESScut', sector=14)
     assert len(results) == 12
     assert len(results.cubedata) == 2
-    manifest = results.cubedata[1].download()
+    assert len(results.tesscut) == 1
+    assert len(results.tesscut) == len(results2)
+    manifest = results.tesscut.download()
     assert len(manifest) == 1
 
 

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -443,7 +443,7 @@ def test_FFI_retrieval():
 def test_tesscut():
     """Can we find and download TESS tesscut tpfs"""
     results = TESSSearch("Kepler 16b", hlsp=False, sector=14)
-    results2 = TESSSearch("Kepler 16b", pipeline="TESScut", sector=14)
+    results2 = TESSSearch("Kepler 16b", pipeline='TESScut', sector=14)
     assert len(results) == 12
     assert len(results.cubedata) == 2
     assert len(results.tesscut) == 1

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -440,7 +440,7 @@ def test_FFI_retrieval():
 def test_tesscut():
     """Can we find and download TESS tesscut tpfs"""
     results = TESSSearch("Kepler 16b", hlsp=False, sector=14)
-    results2 = TESSSearch("Kepler 16b", pipeline='TESScut', sector=14)
+    results2 = TESSSearch("Kepler 16b", pipeline="TESScut", sector=14)
     assert len(results) == 12
     assert len(results.cubedata) == 2
     assert len(results.tesscut) == 1

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -650,8 +650,8 @@ def test_cached_files_no_filesize_check():
     assert manifest["Local Path"][0].startswith("s3://")
     assert manifest["Local Path"][1].startswith("/")
 
-    assert manifest["STATUS"][0] == "COMPLETE"
-    assert manifest["STATUS"][1] == "UNKNOWN"
+    assert manifest["Status"][0] == "COMPLETE"
+    assert manifest["Status"][1] == "UNKNOWN"
 
 
 """The below was working for Christina but not for Tyler or Github Actions.  


### PR DESCRIPTION
This refactors MASTSearch._download_one into MASTSearch._bulk_download, which removes the iterative download to speed up downloads in the case where most of download time is spent connecting to the MAST astroquery server such as when local files exist in the cache and no file is downloaded.  

This also add some documentation (tutorials and docstrings) for the CHECK_CACHED_FILE_SIZES keyword, and new download tests

This also iterates the version number to a new minor version.  
