### PR TITLE
filter TESScut by exptime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Changelog:
 ==========
 v1.2.2
   - Updated the logic surrounding TESScut searches to allow only TESScut results [#32]
-  - filter TESScut results by exposure time keywork [#43]
+  - filter TESScut results by exposure time keyword [#43]
 v1.2.0
   - Made the catalogsearch functions case-insensitive[#38]
   - Added `CHECK_CACHED_FILE_SIZES` configuration parameter, which on download allows local checking of cached files without a remote file-size check[#34][#38]

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,9 @@ Please include a self-contained example that fully demonstrates your problem or 
 
 Changelog:
 ==========
+v1.2.2
+  - Updated the logic surrounding TESScut searches to allow only TESScut results [#32]
+  - filter TESScut results by exposure time keywork [#43]
 v1.2.0
   - Made the catalogsearch functions case-insensitive[#38]
   - Added `CHECK_CACHED_FILE_SIZES` configuration parameter, which on download allows local checking of cached files without a remote file-size check[#34][#38]
@@ -119,7 +122,6 @@ v1.2.0
     - This results in a modest speedup O(N), particularly for files in the local cache when `CHECK_CACHED_FILE_SIZES` is `True`.  
   - Updated tests, documentation for the new features
   - Changed the property cloud_uris(self) to cloud_uri(self) [#42]
-  - Updated the logic surrounding TESScut searches to allow only TESScut results [#32]
 v1.1.1
   - Deprecated TESSSearch.search_sector_ffis due to changes in astroquery functionality
 v1.1.0

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -160,10 +160,11 @@ class TESSSearch(MASTSearch):
         self.table["mission_product"] = mission_product
         self.table["sector"] = self.table["sequence_number"]
 
-    def _add_tesscut_products(self, 
-                              sector_list: Union[int, list[int]],
-                              exptime: Union[int, tuple[float]],
-                              ):
+    def _add_tesscut_products(
+        self,
+        sector_list: Union[int, list[int]],
+        exptime: Union[int, tuple[float]],
+    ):
         """Add tesscut product information to the search table
 
         Parameters
@@ -261,7 +262,6 @@ class TESSSearch(MASTSearch):
                 "year": tesscut_year,
             }
         )
-
 
         if len(tesscut_result) > 0:
             log.debug(f"Found {n_results} matching cutouts.")

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -109,7 +109,8 @@ class TESSSearch(MASTSearch):
             self.table = pd.DataFrame(columns=table_keys)
 
         if (pipeline == None) or ("tesscut" in [p.lower() for p in pipeline]):
-            self._add_tesscut_products(sector)
+            self._add_tesscut_products(sector, exptime=exptime)
+
         if len(self.table) == 0:
             raise SearchError(f"No data found for target {self.target}.")
         self._add_TESS_mission_product()
@@ -159,7 +160,10 @@ class TESSSearch(MASTSearch):
         self.table["mission_product"] = mission_product
         self.table["sector"] = self.table["sequence_number"]
 
-    def _add_tesscut_products(self, sector_list: Union[int, list[int]]):
+    def _add_tesscut_products(self, 
+                              sector_list: Union[int, list[int]],
+                              exptime: Union[int, tuple[float]],
+                              ):
         """Add tesscut product information to the search table
 
         Parameters
@@ -175,6 +179,8 @@ class TESSSearch(MASTSearch):
             self.table = pd.concat([self.table, tesscut_info])
         else:
             self.table = tesscut_info
+        mask = self._mask_by_exptime(exptime=exptime)
+        self.table = self.table[mask]
 
     # FFIs only available when using TESSSearch.
     # Use TESS WCS to just return a table of sectors and dates?
@@ -255,6 +261,7 @@ class TESSSearch(MASTSearch):
                 "year": tesscut_year,
             }
         )
+
 
         if len(tesscut_result) > 0:
             log.debug(f"Found {n_results} matching cutouts.")

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -470,7 +470,7 @@ def test_tesscut():
     # Previously the TESScut data was appended after the exposure time cuts
     #     so it returned 1800s tesscut data [see issue #41]
     with pytest.raises(SearchError, match="No data"):
-        TESSSearch("TOI 1161",  sector=14, exptime=20)
+        TESSSearch("TOI 1161", sector=14, exptime=20)
 
 
 class TestMASTSearchFilter:

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -466,6 +466,12 @@ def test_tesscut():
     assert len(sr) == 1
     assert len(sr2) == 2
 
+    # No 20-s data was taken so this should be empty
+    # Previously the TESScut data was appended after the exposure time cuts
+    #     so it returned 1800s tesscut data [see issue #41]
+    with pytest.raises(SearchError, match="No data"):
+        TESSSearch("TOI 1161",  sector=14, exptime=20)
+
 
 class TestMASTSearchFilter:
     results = MASTSearch("Kepler 16b")


### PR DESCRIPTION
This addresses issue #41, which points out that when returning TESScut data, the exposure time keyword was ignored. This PR now filters by exposure time in _add_tesscut_products(). A test was added to make sure no tesscut results are returned when an exposure time of 20s is given. 