### PR TITLE
Add properties

### DIFF
--- a/src/lksearch/K2Search.py
+++ b/src/lksearch/K2Search.py
@@ -134,7 +134,7 @@ class K2Search(MASTSearch):
                 if f"c{row['sequence_number']}{half}" in row["productFilename"]:
                     seq_num[index] = f"{int(row['sequence_number']):02d}{letter}"
 
-        self.table["campaign"] = seq_num.astype(int)
+        self.table["campaign"] = seq_num
 
     def _sort_K2(self):
         # No specific preference for K2 HLSPs

--- a/src/lksearch/K2Search.py
+++ b/src/lksearch/K2Search.py
@@ -134,7 +134,7 @@ class K2Search(MASTSearch):
                 if f"c{row['sequence_number']}{half}" in row["productFilename"]:
                     seq_num[index] = f"{int(row['sequence_number']):02d}{letter}"
 
-        self.table["campaign"] = seq_num
+        self.table["campaign"] = seq_num.astype(int)
 
     def _sort_K2(self):
         # No specific preference for K2 HLSPs

--- a/src/lksearch/K2Search.py
+++ b/src/lksearch/K2Search.py
@@ -91,6 +91,11 @@ class K2Search(MASTSearch):
             self._sort_K2()
 
     @property
+    def campaign(self):
+        """K2 Observing campaign for each data product found."""
+        return self.table["campaign"].values
+
+    @property
     def HLSPs(self):
         """return a MASTSearch object with self.table only containing High Level Science Products"""
         mask = self.table["mission_product"]

--- a/src/lksearch/KeplerSearch.py
+++ b/src/lksearch/KeplerSearch.py
@@ -95,7 +95,11 @@ class KeplerSearch(MASTSearch):
             self._sort_Kepler()
             # Can't search mast with quarter/month directly, so filter on that after the fact.
             self.table = self.table[self._filter_kepler(quarter, month)]
-
+    @property
+    def quarter(self):
+        """Kepler Observing quarter for each data product found."""
+        return self.table["quarter"].values
+    
     @property
     def HLSPs(self):
         """return a MASTSearch object with self.table only containing High Level Science Products"""

--- a/src/lksearch/KeplerSearch.py
+++ b/src/lksearch/KeplerSearch.py
@@ -95,11 +95,12 @@ class KeplerSearch(MASTSearch):
             self._sort_Kepler()
             # Can't search mast with quarter/month directly, so filter on that after the fact.
             self.table = self.table[self._filter_kepler(quarter, month)]
+
     @property
     def quarter(self):
         """Kepler Observing quarter for each data product found."""
         return self.table["quarter"].values
-    
+
     @property
     def HLSPs(self):
         """return a MASTSearch object with self.table only containing High Level Science Products"""

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -117,7 +117,7 @@ class TESSSearch(MASTSearch):
     def sector(self):
         """TESS Observing sector for each data product found."""
         return self.table["sector"].values
-    
+
     @property
     def HLSPs(self):
         """return a MASTSearch object with self.table only containing High Level Science Products"""

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -1,4 +1,3 @@
-from astroquery.mast import Observations
 import pandas as pd
 from typing import Union, Optional
 import re
@@ -8,14 +7,11 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-from astroquery.mast import MastClass
 
 # from astropy.utils.decorators import deprecated
 from astroquery.mast import Tesscut
 
 from tqdm import tqdm
-
-from copy import deepcopy
 
 from .MASTSearch import MASTSearch
 from . import conf, config, log
@@ -89,7 +85,7 @@ class TESSSearch(MASTSearch):
             self.mission_search = ["TESS"]
         else:
             self.mission_search = ["TESS", "HLSP"]
-        if pipeline != None:
+        if pipeline is not None:
             pipeline = np.atleast_1d(pipeline).tolist()
 
         # Even if there are no higher level products, we may still want to check for tesscut
@@ -108,7 +104,7 @@ class TESSSearch(MASTSearch):
         except SearchError:
             self.table = pd.DataFrame(columns=table_keys)
 
-        if (pipeline == None) or ("tesscut" in [p.lower() for p in pipeline]):
+        if (pipeline is None) or ("tesscut" in [p.lower() for p in pipeline]):
             self._add_tesscut_products(sector, exptime=exptime)
 
         if len(self.table) == 0:

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -118,6 +118,11 @@ class TESSSearch(MASTSearch):
         self._sort_TESS()
 
     @property
+    def sector(self):
+        """TESS Observing sector for each data product found."""
+        return self.table["sector"].values
+    
+    @property
     def HLSPs(self):
         """return a MASTSearch object with self.table only containing High Level Science Products"""
         mask = self.table["mission_product"]

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -85,7 +85,7 @@ class TESSSearch(MASTSearch):
             self.mission_search = ["TESS"]
         else:
             self.mission_search = ["TESS", "HLSP"]
-        if pipeline is not None:
+        if pipeline != None:
             pipeline = np.atleast_1d(pipeline).tolist()
 
         # Even if there are no higher level products, we may still want to check for tesscut

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -2,9 +2,6 @@
 
 import os
 import pytest
-from time import time
-import socket
-from contextlib import contextmanager
 
 from numpy.testing import assert_almost_equal, assert_array_equal
 import numpy as np
@@ -244,7 +241,7 @@ def test_properties():
     assert len(result) == 5
     assert all([r in [2,3,4] for r in result.quarter])
 
-    result = TESSSearch(tic, pipeline="spoc", sector=1, search_radius=100).timeseries
+    result = TESSSearch("TIC 273985862", pipeline="spoc", sector=1, search_radius=100).timeseries
     assert len(result) == 2
     assert len(result.sector) == 2
     assert (result.campaign == '1').all()
@@ -461,7 +458,7 @@ def test_split_k2_campaigns():
 def test_FFI_retrieval():
     """MAST has deprecated FFI search and retrieval through astroquery, so this function is now deprecated"""
     with pytest.raises(SearchDeprecationError) as exc:
-        results = TESSSearch("Kepler 16b").search_sector_ffis(14)
+        TESSSearch("Kepler 16b").search_sector_ffis(14)
     assert "deprecated" in exc.value.args[0]
 
 
@@ -600,7 +597,7 @@ def test_tess_clouduris():
     # 12 products should be returned
     assert len(toi.cloud_uri) == 12
     # 6 of them should have cloud uris
-    assert np.sum((toi.cloud_uri.values != None).astype(int)) == 6
+    assert np.sum((toi.cloud_uri.values is not None).astype(int)) == 6
 
 
 def test_tess_return_clouduri_not_download():

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -229,10 +229,31 @@ def test_collections():
 
 
 def test_properties():
+    """Test an assortment of class properties"""
     c = SkyCoord("297.5835 40.98339", unit=(u.deg, u.deg))
     assert_almost_equal(KeplerSearch(c, quarter=6).cubedata.ra[0], 297.5835)
     assert_almost_equal(KeplerSearch(c, quarter=6).cubedata.dec[0], 40.98339)
     assert len(KeplerSearch(c, quarter=6).cubedata.target_name) == 1
+
+    result = K2Search("EPIC 205998445", search_radius=900, campaign=3).cubedata
+    assert len(result) == 4
+    assert len(result.cloud_uri) == 4
+    assert (result.campaign == '3').all()
+    
+    result = KeplerSearch("KIC 11904151",  exptime="short", quarter=[2,3,4]).cubedata
+    assert len(result) == 5
+    assert all([r in [2,3,4] for r in result.quarter])
+
+    result = TESSSearch(tic, pipeline="spoc", sector=1, search_radius=100).timeseries
+    assert len(result) == 2
+    assert len(result.sector) == 2
+    assert (result.campaign == '1').all()
+    assert (result.mission == "TESS").all()
+    assert (result.pipeline == "SPOC").all()
+
+
+    with pytest.raises(AttributeError, match="no attibute"):
+        result = MASTSearch("EPIC 205998445", search_radius=900).cubedata
 
 
 def test_source_confusion():

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -235,7 +235,7 @@ def test_properties():
     result = K2Search("EPIC 205998445", search_radius=900, campaign=3).cubedata
     assert len(result) == 4
     assert len(result.cloud_uri) == 4
-    assert (result.campaign == "3").all()
+    assert (result.campaign == 3).all()
 
     result = KeplerSearch("KIC 11904151", exptime="short", quarter=[2, 3, 4]).cubedata
     assert len(result) == 5
@@ -246,7 +246,7 @@ def test_properties():
     ).timeseries
     assert len(result) == 2
     assert len(result.sector) == 2
-    assert (result.sector == "1").all()
+    assert (result.sector == 1).all()
     assert (result.mission == "TESS").all()
     assert (result.pipeline == "SPOC").all()
 

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -235,7 +235,8 @@ def test_properties():
     result = K2Search("EPIC 205998445", search_radius=900, campaign=3).cubedata
     assert len(result) == 4
     assert len(result.cloud_uri) == 4
-    assert (result.campaign == 3).all()
+    # Campaign is a string, as campaigns can have 'a' and 'b' components
+    assert (result.campaign == "3").all()
 
     result = KeplerSearch("KIC 11904151", exptime="short", quarter=[2, 3, 4]).cubedata
     assert len(result) == 5
@@ -251,7 +252,7 @@ def test_properties():
     assert (result.pipeline == "SPOC").all()
 
     with pytest.raises(AttributeError, match="no attibute"):
-        result = MASTSearch("EPIC 205998445", search_radius=900).cubedata
+        MASTSearch("EPIC 205998445", mission='TESS', search_radius=900).cubedata.sector
 
 
 def test_source_confusion():

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -251,7 +251,7 @@ def test_properties():
     assert (result.mission == "TESS").all()
     assert (result.pipeline == "SPOC").all()
 
-    with pytest.raises(AttributeError, match="no attibute"):
+    with pytest.raises(AttributeError, match="no attribute"):
         MASTSearch("EPIC 205998445", mission="TESS", search_radius=900).cubedata.sector
 
 

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -246,7 +246,7 @@ def test_properties():
     ).timeseries
     assert len(result) == 2
     assert len(result.sector) == 2
-    assert (result.campaign == "1").all()
+    assert (result.sector == "1").all()
     assert (result.mission == "TESS").all()
     assert (result.pipeline == "SPOC").all()
 
@@ -598,7 +598,7 @@ def test_tess_clouduris():
     # 12 products should be returned
     assert len(toi.cloud_uri) == 12
     # 6 of them should have cloud uris
-    assert np.sum((toi.cloud_uri.values is not None).astype(int)) == 6
+    assert np.sum((toi.cloud_uri.values != None).astype(int)) == 6
 
 
 def test_tess_return_clouduri_not_download():

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -235,19 +235,20 @@ def test_properties():
     result = K2Search("EPIC 205998445", search_radius=900, campaign=3).cubedata
     assert len(result) == 4
     assert len(result.cloud_uri) == 4
-    assert (result.campaign == '3').all()
-    
-    result = KeplerSearch("KIC 11904151",  exptime="short", quarter=[2,3,4]).cubedata
-    assert len(result) == 5
-    assert all([r in [2,3,4] for r in result.quarter])
+    assert (result.campaign == "3").all()
 
-    result = TESSSearch("TIC 273985862", pipeline="spoc", sector=1, search_radius=100).timeseries
+    result = KeplerSearch("KIC 11904151", exptime="short", quarter=[2, 3, 4]).cubedata
+    assert len(result) == 5
+    assert all([r in [2, 3, 4] for r in result.quarter])
+
+    result = TESSSearch(
+        "TIC 273985862", pipeline="spoc", sector=1, search_radius=100
+    ).timeseries
     assert len(result) == 2
     assert len(result.sector) == 2
-    assert (result.campaign == '1').all()
+    assert (result.campaign == "1").all()
     assert (result.mission == "TESS").all()
     assert (result.pipeline == "SPOC").all()
-
 
     with pytest.raises(AttributeError, match="no attibute"):
         result = MASTSearch("EPIC 205998445", search_radius=900).cubedata

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -252,7 +252,7 @@ def test_properties():
     assert (result.pipeline == "SPOC").all()
 
     with pytest.raises(AttributeError, match="no attibute"):
-        MASTSearch("EPIC 205998445", mission='TESS', search_radius=900).cubedata.sector
+        MASTSearch("EPIC 205998445", mission="TESS", search_radius=900).cubedata.sector
 
 
 def test_source_confusion():


### PR DESCRIPTION
This PR adds relevant properties for the different data products. Namely

- 'sector' for TESSSearch
- 'campaign' for K2Search
- 'quarter' for KeplerSearch

This PR also adds tests for these new properties. 