### PR TITLE
Removing duplicated rows when querying TIC

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.12' 
       - uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: '3.1.11' # The pandoc version to download (if necessary) and use.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/src/lksearch/MASTSearch.py
+++ b/src/lksearch/MASTSearch.py
@@ -12,11 +12,10 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.time import Time
-from tqdm import tqdm
 
 from copy import deepcopy
 
-from .utils import SearchError, SearchWarning, suppress_stdout
+from .utils import SearchError, SearchWarning
 
 from . import conf, config, log
 

--- a/src/lksearch/TESSSearch.py
+++ b/src/lksearch/TESSSearch.py
@@ -85,7 +85,7 @@ class TESSSearch(MASTSearch):
             self.mission_search = ["TESS"]
         else:
             self.mission_search = ["TESS", "HLSP"]
-        if pipeline != None:
+        if pipeline is not None:
             pipeline = np.atleast_1d(pipeline).tolist()
 
         # Even if there are no higher level products, we may still want to check for tesscut

--- a/src/lksearch/catalogsearch.py
+++ b/src/lksearch/catalogsearch.py
@@ -155,10 +155,11 @@ def query_region(
 
     result = result[catalog_name]
     # Remove rows with bad Disp if catalog is TIC and Disp in on of the columns.
-    # A bad Dips is one of [DUPLICATE, ARTIFACT, SPLIT]
+    # A bad Dips is one of [DUPLICATE, ARTIFACT]
     # see for details https://outerspace.stsci.edu/spaces/TESS/pages/40927681/TIC+v8+and+CTL+v8.xx+Data+Release+Notes
+    # we keep "SPLIT" as these are expected to be true sources that were originally blended. 
     if "Disp" in result.columns:
-        result = result[~np.isin(result["Disp"], ["DUPLICATE", "ARTIFACT", "SPLIT"])]
+        result = result[~np.isin(result["Disp"], ["DUPLICATE", "ARTIFACT"])]
         # we remove the column
         result.remove_column("Disp")
     # Rename the columns so that the output is uniform

--- a/src/lksearch/catalogsearch.py
+++ b/src/lksearch/catalogsearch.py
@@ -155,7 +155,7 @@ def query_region(
 
     result = result[catalog_name]
     # Remove rows with bad Disp if catalog is TIC and Disp in on of the columns.
-    # A bad Dips is one of [DUPLICATE, ARTIFACT]
+    # A bad Disp is one of [DUPLICATE, ARTIFACT]
     # see for details https://outerspace.stsci.edu/spaces/TESS/pages/40927681/TIC+v8+and+CTL+v8.xx+Data+Release+Notes
     # we keep "SPLIT" as these are expected to be true sources that were originally blended.
     if "Disp" in result.columns:

--- a/src/lksearch/catalogsearch.py
+++ b/src/lksearch/catalogsearch.py
@@ -154,6 +154,13 @@ def query_region(
         return empty_table
 
     result = result[catalog_name]
+    # Remove rows with bad Disp if catalog is TIC and Disp in on of the columns.
+    # A bad Dips is one of [DUPLICATE, ARTIFACT, SPLIT]
+    # see for details https://outerspace.stsci.edu/spaces/TESS/pages/40927681/TIC+v8+and+CTL+v8.xx+Data+Release+Notes
+    if "Disp" in result.columns:
+        result = result[~np.isin(result["Disp"], ["DUPLICATE", "ARTIFACT", "SPLIT"])]
+        # we remove the column
+        result.remove_column("Disp")
     # Rename the columns so that the output is uniform
     result.rename_columns(
         catalog_meta["rename_in"],

--- a/src/lksearch/catalogsearch.py
+++ b/src/lksearch/catalogsearch.py
@@ -157,7 +157,7 @@ def query_region(
     # Remove rows with bad Disp if catalog is TIC and Disp in on of the columns.
     # A bad Dips is one of [DUPLICATE, ARTIFACT]
     # see for details https://outerspace.stsci.edu/spaces/TESS/pages/40927681/TIC+v8+and+CTL+v8.xx+Data+Release+Notes
-    # we keep "SPLIT" as these are expected to be true sources that were originally blended. 
+    # we keep "SPLIT" as these are expected to be true sources that were originally blended.
     if "Disp" in result.columns:
         result = result[~np.isin(result["Disp"], ["DUPLICATE", "ARTIFACT"])]
         # we remove the column

--- a/src/lksearch/catalogsearch.py
+++ b/src/lksearch/catalogsearch.py
@@ -442,7 +442,8 @@ def _query_names(search_item):
 
     # Older astroquery versions return bytes-like objects, lets make sure things are strings
     for col, dtype in result_table.dtypes.items():
-        if dtype == object and col == "ID":  # Only process byte object columns
+        # "0" is numpy's internal string code for objects
+        if dtype == "O" and col == "ID":  # Only process byte object columns
             result_table[col] = result_table[col].str.decode("utf-8")
 
     # older astroquery versions use "ID" not 'id', lets be backwards compatible

--- a/src/lksearch/data/catalog_config.json
+++ b/src/lksearch/data/catalog_config.json
@@ -78,7 +78,8 @@
             "logg",
             "Teff",
             "Rad",
-            "Mass"
+            "Mass",
+            "Disp"
         ],
         "column_filters": "Tmag",
         "rename_in": [

--- a/tests/test_catalogs_conesearch.py
+++ b/tests/test_catalogs_conesearch.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pandas as pd
 from astropy.coordinates import SkyCoord
-from astropy.table import Table
 from astropy.time import Time
 import astropy.units as u
 from lksearch.catalogsearch import query_region

--- a/tests/test_catalogs_idsearch.py
+++ b/tests/test_catalogs_idsearch.py
@@ -1,10 +1,6 @@
 """Tests catalog id querying"""
 
-import numpy as np
 from astropy.coordinates import SkyCoord
-import pandas as pd
-from astropy.time import Time
-import astropy.units as u
 from lksearch.catalogsearch import query_id
 
 
@@ -96,7 +92,7 @@ def test_crossmatch():
     assert len(result) == 1
     assert result["Source"].values == 2133452475178900736
 
-    result = query_id(f"KIC 12644769", output_catalog="tic")
+    result = query_id("KIC 12644769", output_catalog="tic")
     assert len(result) == 1
     assert result["TIC"].values == 299096355
 

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -600,12 +600,12 @@ def test_tess_clouduris():
     assert len(toi.cloud_uri) == 12
     # 6 of them should have cloud uris
     # JMP: 2026-08-04 MAST changed how files without uri are handled now it uses
-    # 'nan' instead of None. DV and TCE reports are in S3 buckets now. Only the 
+    # 'nan' instead of None. DV and TCE reports are in S3 buckets now. Only the
     # TESScut from the FFI does not have and uri.
-    assert np.sum((toi.cloud_uri.values != 'nan').astype(int)) == 11
+    assert np.sum((toi.cloud_uri.values != "nan").astype(int)) == 11
 
 
-# JMP: 2026-08-04 
+# JMP: 2026-08-04
 # MAST moved DV reports to S3 buckets and seems that they will do this for all DV reports
 # in the future. For the moment we sill skip this test until we come up with something
 # more robust.

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -599,29 +599,36 @@ def test_tess_clouduris():
     # 12 products should be returned
     assert len(toi.cloud_uri) == 12
     # 6 of them should have cloud uris
-    assert np.sum((toi.cloud_uri.values != None).astype(int)) == 6
+    # JMP: 2026-08-04 MAST changed how files without uri are handled now it uses
+    # 'nan' instead of None. DV and TCE reports are in S3 buckets now. Only the 
+    # TESScut from the FFI does not have and uri.
+    assert np.sum((toi.cloud_uri.values != 'nan').astype(int)) == 11
 
 
-def test_tess_return_clouduri_not_download():
-    """Test to see if we return a S3 bucket instead of downloading if
-    `~conf.DOWNLOAD_CLOUD` = False
-    """
-    # reload the config, set download_cloud = False
-    conf.reload()
-    conf.DOWNLOAD_CLOUD = False
-    # Try to download a file without a S3 bucket, and one with
-    # Search for TESS data only. This by default includes both HLSPs and FFI cutouts.
-    toi = TESSSearch("TOI 1161", sector=14)
-    uris = toi.dvreports.cloud_uri
-    not_cloud = pd.isna(uris)
-    # A DV Report is not on the cloud - this should still get downloaded locally
-    dvr = toi.dvreports[not_cloud]
-    dvr_man = dvr[0].download()
-    assert os.path.isfile(dvr_man["Local Path"][0])
-    # A SPOC TPF is on the cloud, this should return a S3 bucket
-    mask = toi.timeseries.pipeline == "SPOC"
-    lc_man = toi.timeseries[mask][0].download()
-    assert lc_man["Local Path"][0].startswith("s3://")
+# JMP: 2026-08-04 
+# MAST moved DV reports to S3 buckets and seems that they will do this for all DV reports
+# in the future. For the moment we sill skip this test until we come up with something
+# more robust.
+# def test_tess_return_clouduri_not_download():
+#     """Test to see if we return a S3 bucket instead of downloading if
+#     `~conf.DOWNLOAD_CLOUD` = False
+#     """
+#     # reload the config, set download_cloud = False
+#     conf.reload()
+#     conf.DOWNLOAD_CLOUD = False
+#     # Try to download a file without a S3 bucket, and one with
+#     # Search for TESS data only. This by default includes both HLSPs and FFI cutouts.
+#     toi = TESSSearch("TOI 1161", sector=14)
+#     uris = toi.dvreports.cloud_uri
+#     not_cloud = pd.isna(uris)
+#     # A DV Report is not on the cloud - this should still get downloaded locally
+#     dvr = toi.dvreports[not_cloud]
+#     dvr_man = dvr[0].download()
+#     assert os.path.isfile(dvr_man["Local Path"][0])
+#     # A SPOC TPF is on the cloud, this should return a S3 bucket
+#     mask = toi.timeseries.pipeline == "SPOC"
+#     lc_man = toi.timeseries[mask][0].download()
+#     assert lc_man["Local Path"][0].startswith("s3://")
 
 
 def test_cached_files_no_filesize_check():

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -598,7 +598,7 @@ def test_tess_clouduris():
     toi = TESSSearch("TOI 1161", hlsp=False, sector=14)
     # 12 products should be returned
     assert len(toi.cloud_uri) == 12
-    # 6 of them should have cloud uris
+    # 1 of them should have cloud uris FFI cutout from TESScut
     # JMP: 2026-08-04 MAST changed how files without uri are handled now it uses
     # 'nan' instead of None. DV and TCE reports are in S3 buckets now. Only the
     # TESScut from the FFI does not have and uri.
@@ -607,28 +607,25 @@ def test_tess_clouduris():
 
 # JMP: 2026-08-04
 # MAST moved DV reports to S3 buckets and seems that they will do this for all DV reports
-# in the future. For the moment we sill skip this test until we come up with something
-# more robust.
-# def test_tess_return_clouduri_not_download():
-#     """Test to see if we return a S3 bucket instead of downloading if
-#     `~conf.DOWNLOAD_CLOUD` = False
-#     """
-#     # reload the config, set download_cloud = False
-#     conf.reload()
-#     conf.DOWNLOAD_CLOUD = False
-#     # Try to download a file without a S3 bucket, and one with
-#     # Search for TESS data only. This by default includes both HLSPs and FFI cutouts.
-#     toi = TESSSearch("TOI 1161", sector=14)
-#     uris = toi.dvreports.cloud_uri
-#     not_cloud = pd.isna(uris)
-#     # A DV Report is not on the cloud - this should still get downloaded locally
-#     dvr = toi.dvreports[not_cloud]
-#     dvr_man = dvr[0].download()
-#     assert os.path.isfile(dvr_man["Local Path"][0])
-#     # A SPOC TPF is on the cloud, this should return a S3 bucket
-#     mask = toi.timeseries.pipeline == "SPOC"
-#     lc_man = toi.timeseries[mask][0].download()
-#     assert lc_man["Local Path"][0].startswith("s3://")
+# in the future. For the moment we'll test all DV reports are on cloud until we come up 
+# with something more robust.
+def test_tess_rvreports_on_cloud():
+    """Test to see if we return a S3 bucket instead of downloading if
+    `~conf.DOWNLOAD_CLOUD` = False
+    """
+    # reload the config, set download_cloud = False
+    conf.reload()
+    conf.DOWNLOAD_CLOUD = False
+    # Search for TESS data only. This by default includes both HLSPs and FFI cutouts.
+    toi = TESSSearch("TOI 1161", sector=14)
+    uris = toi.dvreports.cloud_uri
+    not_cloud = pd.isna(uris)
+    # DV reports are all on cloud
+    assert not not_cloud.any()
+    # A SPOC TPF is on the cloud, this should return a S3 bucket
+    mask = toi.timeseries.pipeline == "SPOC"
+    lc_man = toi.timeseries[mask][0].download()
+    assert lc_man["Local Path"][0].startswith("s3://")
 
 
 def test_cached_files_no_filesize_check():

--- a/tests/test_missionsearch.py
+++ b/tests/test_missionsearch.py
@@ -607,7 +607,7 @@ def test_tess_clouduris():
 
 # JMP: 2026-08-04
 # MAST moved DV reports to S3 buckets and seems that they will do this for all DV reports
-# in the future. For the moment we'll test all DV reports are on cloud until we come up 
+# in the future. For the moment we'll test all DV reports are on cloud until we come up
 # with something more robust.
 def test_tess_rvreports_on_cloud():
     """Test to see if we return a S3 bucket instead of downloading if


### PR DESCRIPTION
The TIC v8.x has problematic rows that refer to duplicated objects or missidentifed ones. Currently `query_region(catalog="tic)` returns all rows in the TIC, including these problematic rows. This PR cleans the returned catalog by removing rows identified as "DUPLICATE" or "ARTIFACT". Rows with "SPLIT" are kept as these are single object that due to better resolution (Gaia DR2) more objects were identified in the latest version of the TIC. 

Other fixes in this PR:
- Documentation CI fixed to use python 3.12 to avoid libjpeg dependency issue from pillow when running python 3.14
- Skips `test_tess_return_clouduri_not_download()` pytest as MAST changed to store DV reports in S3 buckets.
- Updates assetion in `test_tess_clouduris()` pytest to reflect changes in S3 URIs for reports and default value for non existing URIs. 